### PR TITLE
[TVMScript] Parse type/shape annotation with StructInfo 

### DIFF
--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -54,9 +54,11 @@ TVM_DLL FunctionFrame Function();
  * \param name The name of the parameter.
  * \param type The type of the parameter.
  * \param shape The shape of the parameter.
+ * \param struct_info The struct_info of the parameter.
  * \return The created function parameter var.
  */
-TVM_DLL tvm::relax::Var Arg(const String& name, const Type& type, const tvm::relax::Expr& shape);
+TVM_DLL tvm::relax::Var Arg(const String& name, const Type& type, const tvm::relax::Expr& shape,
+                            const Optional<tvm::relax::StructInfo>& struct_info);
 
 /*!
  * \brief Specify the name of the last function frame.

--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -20,6 +20,7 @@
 #define TVM_SCRIPT_IR_BUILDER_RELAX_IR_H_
 
 #include <tvm/relax/expr.h>
+#include <tvm/relax/struct_info.h>
 #include <tvm/script/ir_builder/base.h>
 #include <tvm/script/ir_builder/relax/frame.h>
 
@@ -58,13 +59,14 @@ class ShapedType : public runtime::ObjectRef {
 };
 
 /*!
- * \brief Create a ShapedType for a DynTensor.
+ * \brief Create a TensorStructInfo.
  * \param shape The shape of the tensor. It's runtime dependent if `shape` is None.
  * \param dtype The element data type of the tensor. It's runtime dependent if `dtype` is None.
  * \param ndim The number of dimensions of the tensor. It's runtime dependent if `ndim` is -1.
- * \return The ShapedType that is only used in ir_builder.
+ * \return The TensorStructInfo.
  */
-TVM_DLL ShapedType Tensor(Optional<Array<PrimExpr>> shape, DataType dtype, int ndim = -1);
+TVM_DLL tvm::relax::TensorStructInfo Tensor(Optional<Array<PrimExpr>> shape, DataType dtype,
+                                            int ndim = -1);
 
 TVM_DLL ShapedType CreateShapedTuple(Array<Type> types, Array<Optional<tvm::relax::Expr>> shapes);
 
@@ -162,11 +164,13 @@ TVM_DLL Optional<tvm::relax::Var> EmitMatchShape(const tvm::relax::Expr& value, 
  * \param var The input var to be annotated.
  * \param anno_type The annotated type.
  * \param anno_shape The annotated shape, which can be undefined.
+ * \param anno_sinfo The annotated struct info, which can be undefined.
  * \note This function will check if the type of var is compatible with the annotated type.
  * And we annotate to the var with more detailed type.
  */
 TVM_DLL void AnnotateTypeShape(const tvm::relax::Var& var, const Type& anno_type,
-                               const Optional<tvm::relax::Expr>& anno_shape);
+                               const Optional<tvm::relax::Expr>& anno_shape,
+                               const Optional<tvm::relax::StructInfo>& anno_sinfo);
 
 ///////////////////////////// If Then Else /////////////////////////////
 

--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -29,34 +29,7 @@ namespace script {
 namespace ir_builder {
 namespace relax {
 
-////////////////////////////// Shaped Type //////////////////////////////
-
-/*!
- * \brief A temporary data structure for unified type and shape in ir_builder.
- * \note Used for `R.Tensor` and `R.Tuple`
- */
-class ShapedTypeNode : public runtime::Object {
- public:
-  /*! \brief The type, usually is DynTensorType or TupleType */
-  Type type;
-  /*! \brief The shape, which is optional. */
-  Optional<tvm::relax::Expr> shape;
-
-  void VisitAttrs(tvm::AttrVisitor* v) {
-    v->Visit("type", &type);
-    v->Visit("shape", &shape);
-  }
-
-  static constexpr const char* _type_key = "script.ir_builder.relax.ShapedType";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ShapedTypeNode, runtime::Object);
-};
-
-class ShapedType : public runtime::ObjectRef {
- public:
-  TVM_DLL explicit ShapedType(Type type, Optional<tvm::relax::Expr> shape);
-
-  TVM_DEFINE_OBJECT_REF_METHODS(ShapedType, ObjectRef, ShapedTypeNode);
-};
+//////////////////////////////// Tensor /////////////////////////////////
 
 /*!
  * \brief Create a TensorStructInfo.
@@ -67,8 +40,6 @@ class ShapedType : public runtime::ObjectRef {
  */
 TVM_DLL tvm::relax::TensorStructInfo Tensor(Optional<Array<PrimExpr>> shape, DataType dtype,
                                             int ndim = -1);
-
-TVM_DLL ShapedType CreateShapedTuple(Array<Type> types, Array<Optional<tvm::relax::Expr>> shapes);
 
 /////////////////////////////// Function ////////////////////////////////
 
@@ -101,7 +72,7 @@ TVM_DLL void FuncAttrs(Map<String, ObjectRef> attrs);
 
 /*!
  * \brief Specify the return type of the last function frame.
- * \param ret_type The return type. Note: it's a standard `tvm::Type` instead of ShapedType.
+ * \param ret_type The return type.
  */
 TVM_DLL void FuncRetType(tvm::Type ret_type);
 

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -21,7 +21,6 @@ import functools
 from typing import Dict, List, Optional, Tuple, Union
 
 import tvm
-from tvm._ffi import register_object as _register_object
 from tvm.ir import Type
 from tvm.relax import Call, Expr, ExternFunc, ShapeExpr, TupleGetItem, TupleType, Var, const
 from tvm.relax.struct_info import StructInfo, TensorStructInfo, get_type_shape_from_structure_info
@@ -41,7 +40,6 @@ from tvm.relax.op import (
     unique,
     memory,
 )
-from tvm.relax.ty import ObjectType, ShapeType, DynTensorType
 from tvm.relax.utils import convert_to_expr
 from tvm.runtime import Object as tvm_Object
 from tvm.tir import PrimExpr
@@ -50,14 +48,6 @@ from ..tir import var as _tir_var
 from . import _ffi_api, frame
 
 ############################## Tensor Type ##############################
-
-
-@_register_object("script.ir_builder.relax.ShapedType")
-class ShapedType(tvm_Object):
-    """A temporary Tensor type for `R.Tensor` in ir_builder."""
-
-    type: DynTensorType
-    shape: Optional[Expr]
 
 
 def tensor(
@@ -89,22 +79,6 @@ def tensor(
                 shape[i] = _tir_var("int64", s)
 
     return _ffi_api.Tensor(shape, dtype, ndim)  # pylint: disable=no-member # type: ignore
-
-
-def create_shaped_tuple(types: List[Type], shapes: List[Optional[Expr]]) -> ShapedType:
-    """Helper function for `R.Tuple` in parser
-    Parameters
-    ----------
-    types: List[Type]
-        The list of type of it's fields
-    shapes: List[Optional[Expr]]
-        The list of shape of it's fields.
-    Returns
-    -------
-    tuple_type: ShapedType
-        The ShapedType that is only used in ir_builder.
-    """
-    return _ffi_api.CreateShapedTuple(types, shapes)  # pylint: disable=no-member # type: ignore
 
 
 ############################## Other Types ##############################
@@ -417,7 +391,6 @@ __all__ = [
     "If",
     "Object",
     "Shape",
-    "ShapedType",
     "Then",
     "TupleGetItem",
     "Void",
@@ -428,7 +401,6 @@ __all__ = [
     "call_packed",
     "call_tir",
     "const",
-    "create_shaped_tuple",
     "dataflow",
     "emit",
     "emit_match_shape",

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -100,7 +100,12 @@ def function() -> frame.FunctionFrame:
     return _ffi_api.Function()  # pylint: disable=no-member # type: ignore
 
 
-def arg(name: str, type: Union[Type, StructInfo], shape: Optional[ShapeExpr] = None) -> Var:
+def arg(
+    name: str,
+    type: Union[Type, StructInfo],
+    shape: Optional[ShapeExpr] = None,
+    struct_info: Optional[StructInfo] = None,
+) -> Var:
     """Add a parameter to the last function frame.
     Parameters
     ----------
@@ -124,7 +129,7 @@ def arg(name: str, type: Union[Type, StructInfo], shape: Optional[ShapeExpr] = N
     elif not isinstance(type, Type):
         raise TypeError(f"Expect a Type or a StructInfo, but got {type}")
 
-    return _ffi_api.Arg(name, type, shape)  # pylint: disable=no-member # type: ignore
+    return _ffi_api.Arg(name, type, shape, struct_info)  # pylint: disable=no-member # type: ignore
 
 
 def func_name(name: str) -> None:

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -16,11 +16,12 @@
 # under the License.
 # pylint: disable=missing-docstring
 
-from typing import Any, Union
 import numbers
+from typing import Any, Optional, Tuple, Union
 
 from tvm import relax, tir
 from tvm.ir import Type
+from tvm.relax import StructInfo, Expr
 from tvm.relax.utils import convert_to_expr
 from tvm.script.ir_builder.relax.frame import BlockFrame
 
@@ -28,7 +29,7 @@ from ...ir_builder import ir as I
 from ...ir_builder import relax as R
 from ...ir_builder.base import IRBuilder
 from .._core import Parser, dispatch, doc
-from .entry import MatchShapePair, Tensor, ShapedType
+from .entry import MatchShapePair, ShapedType, Tensor
 
 
 def bind_assign_value(self: Parser, node: doc.expr, var_name: str, value: Any) -> Any:
@@ -107,17 +108,25 @@ def eval_shape_annotation(
         return None
 
 
-def eval_type_annotation(self: Parser, node: Union[doc.Expression, doc.expr]) -> Any:
-    type_annotation = self.eval_expr(node)
-    if callable(type_annotation):
-        type_annotation = Tensor()
-    if isinstance(type_annotation, ShapedType):
-        shape = eval_shape_annotation(self, node, type_annotation.shape)
-        return type_annotation.type, shape
+def eval_type_annotation(
+    self: Parser, node: Union[doc.Expression, doc.expr]
+) -> Tuple[Type, Optional[Expr], StructInfo]:
+    annotation = self.eval_expr(node)
+    if callable(annotation):
+        annotation = Tensor()
+    if isinstance(annotation, StructInfo):
+        type_, shape = relax.struct_info.get_type_shape_from_structure_info(annotation)
+        shape = eval_shape_annotation(self, node, shape)
+        return type_, shape, annotation
+    elif isinstance(annotation, ShapedType):
+        # Old path: should be removed
+        shape = eval_shape_annotation(self, node, annotation.shape)
+        return annotation.type, shape, None
     else:
-        if not isinstance(type_annotation, Type):
-            self.report_error(node, f"Unsupported type annotation {type(type_annotation)}")
-        return type_annotation, None
+        # Old path: should be removed
+        if not isinstance(annotation, Type):
+            self.report_error(node, f"Unsupported type annotation {type(annotation)}")
+        return annotation, None, None
 
 
 @dispatch.register(token="relax", type_name="FunctionDef")
@@ -126,7 +135,7 @@ def visit_function_def(self: Parser, node: doc.FunctionDef) -> None:
         with R.function():
             R.func_name(node.name)
             if node.returns is not None:
-                ann_type, ann_shape = eval_type_annotation(self, node.returns)
+                ann_type, ann_shape, ann_sinfo = eval_type_annotation(self, node.returns)
                 R.func_ret_type(ann_type)
 
                 # TODO(relax-team): remove the following line when fixing ret_shape issue
@@ -143,13 +152,13 @@ def visit_tvm_declare_function(self: Parser, node: doc.FunctionDef) -> None:
     if node.returns is None:
         ret_type, ret_shape = None, None
     else:
-        ret_type, ret_shape = eval_type_annotation(self, node.returns)
+        ret_type, ret_shape, ret_sinfo = eval_type_annotation(self, node.returns)
     params = []
     arg_types = []
     for arg in node.args.args:
         if arg.annotation is None:
             self.report_error(arg, "Type annotation is required for function parameters.")
-        param_type, param_shape = self.visit_tvm_annotation(arg.annotation)
+        param_type, param_shape, param_sinfo = self.visit_tvm_annotation(arg.annotation)
         arg_types.append(param_type)
         params.append(relax.Var(arg.arg, param_shape, param_type))
 
@@ -193,7 +202,7 @@ def visit_arguments(self: Parser, node: doc.arguments) -> None:
     for arg in node.args:
         if arg.annotation is None:
             self.report_error(arg, "Type annotation is required for function parameters.")
-        param_type, param_shape = self.visit_tvm_annotation(arg.annotation)
+        param_type, param_shape, param_sinfo = self.visit_tvm_annotation(arg.annotation)
         param = R.arg(arg.arg, param_type, param_shape)
 
         self.var_table.add(arg.arg, param)
@@ -243,7 +252,7 @@ def visit_assign(self: Parser, node: doc.Assign) -> None:
 def visit_ann_assign(self: Parser, node: doc.AnnAssign) -> None:
     lhs = node.target
     rhs = self.eval_expr(node.value)
-    ann_type, ann_shape = self.visit_tvm_annotation(node.annotation)
+    ann_type, ann_shape, ann_sinfo = self.visit_tvm_annotation(node.annotation)
     self.eval_assign(
         target=lhs,
         source=rhs,
@@ -252,7 +261,7 @@ def visit_ann_assign(self: Parser, node: doc.AnnAssign) -> None:
     )
     var = self.var_table.get().get(lhs.id)
     assert isinstance(var, relax.Var)
-    R.ir.annotate_type_shape(var, ann_type, ann_shape)
+    R.ir.annotate_type_shape(var, ann_type, ann_shape, ann_sinfo)
 
 
 @dispatch.register(token="relax", type_name="Return")

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -29,7 +29,7 @@ from ...ir_builder import ir as I
 from ...ir_builder import relax as R
 from ...ir_builder.base import IRBuilder
 from .._core import Parser, dispatch, doc
-from .entry import MatchShapePair, ShapedType, Tensor
+from .entry import MatchShapePair, Tensor
 
 
 def bind_assign_value(self: Parser, node: doc.expr, var_name: str, value: Any) -> Any:
@@ -118,12 +118,7 @@ def eval_type_annotation(
         type_, shape = relax.struct_info.get_type_shape_from_structure_info(annotation)
         shape = eval_shape_annotation(self, node, shape)
         return type_, shape, annotation
-    elif isinstance(annotation, ShapedType):
-        # Old path: should be removed
-        shape = eval_shape_annotation(self, node, annotation.shape)
-        return annotation.type, shape, None
     else:
-        # Old path: should be removed
         if not isinstance(annotation, Type):
             self.report_error(node, f"Unsupported type annotation {type(annotation)}")
         return annotation, None, None

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -198,7 +198,7 @@ def visit_arguments(self: Parser, node: doc.arguments) -> None:
         if arg.annotation is None:
             self.report_error(arg, "Type annotation is required for function parameters.")
         param_type, param_shape, param_sinfo = self.visit_tvm_annotation(arg.annotation)
-        param = R.arg(arg.arg, param_type, param_shape)
+        param = R.arg(arg.arg, param_type, param_shape, param_sinfo)
 
         self.var_table.add(arg.arg, param)
 

--- a/src/relax/ir/struct_info.cc
+++ b/src/relax/ir/struct_info.cc
@@ -101,6 +101,7 @@ TensorStructInfo::TensorStructInfo(DataType dtype, int ndim, Span span) {
   n->ndim = ndim;
   n->dtype = dtype;
   n->span = span;
+  n->shape = RuntimeDepShape();
   data_ = std::move(n);
 }
 

--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -49,15 +49,6 @@ TVM_STATIC_IR_FUNCTOR(Namer, vtable)
 
 ////////////////////////////// Tensor Type //////////////////////////////
 
-ShapedType::ShapedType(Type type, Optional<tvm::relax::Expr> shape) {
-  auto n = make_object<ShapedTypeNode>();
-  n->type = std::move(type);
-  n->shape = std::move(shape);
-  data_ = std::move(n);
-}
-
-TVM_REGISTER_NODE_TYPE(ShapedTypeNode);
-
 using tvm::relax::TensorStructInfo;
 using tvm::relax::TupleStructInfo;
 
@@ -78,29 +69,7 @@ TensorStructInfo Tensor(Optional<Array<PrimExpr>> shape, DataType dtype, int ndi
   }
 }
 
-ShapedType CreateShapedTuple(Array<Type> types, Array<Optional<tvm::relax::Expr>> shapes) {
-  CHECK_EQ(types.size(), shapes.size())
-      << "ValueError: The number of types and shapes mismatched, got " << types.size() << " vs "
-      << shapes.size();
-  Array<tvm::relax::Expr> _shapes;
-  bool has_none_shape = false;
-  for (const auto& shape : shapes) {
-    if (shape.defined()) {
-      _shapes.push_back(shape.value());
-    } else {
-      has_none_shape = true;
-      break;
-    }
-  }
-  Optional<tvm::relax::Expr> final_shape = NullOpt;
-  if (!has_none_shape) {
-    final_shape = tvm::relax::Tuple(_shapes);
-  }
-  return ShapedType(TupleType(types), final_shape);
-}
-
 TVM_REGISTER_GLOBAL("script.ir_builder.relax.Tensor").set_body_typed(Tensor);
-TVM_REGISTER_GLOBAL("script.ir_builder.relax.CreateShapedTuple").set_body_typed(CreateShapedTuple);
 
 /////////////////////////////// Function ////////////////////////////////
 

--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -84,9 +84,11 @@ FunctionFrame Function() {
   return FunctionFrame(n);
 }
 
-tvm::relax::Var Arg(const String& name, const Type& type, const tvm::relax::Expr& shape) {
+tvm::relax::Var Arg(const String& name, const Type& type, const tvm::relax::Expr& shape,
+                    const Optional<tvm::relax::StructInfo>& struct_info) {
   FunctionFrame frame = FindFunctionFrame("R.Arg");
   tvm::relax::Var var(name, shape, type);
+  var->struct_info_ = struct_info;
   frame->params.push_back(var);
   return var;
 }


### PR DESCRIPTION
This PR removed `ShapedType` and use StructInfo to handle type annotation. 