### PR TITLE
misc fixes

### DIFF
--- a/include/tvm/relax/analysis.h
+++ b/include/tvm/relax/analysis.h
@@ -91,8 +91,7 @@ TVM_DLL StructInfo StructInfoFromType(const Type& type);
  * \param shape_hint The shape hint
  * \return the corresponding struct info.
  */
-TVM_DLL StructInfo StructInfoFromTypeLegacyShapeHint(
-    const Type& type, Optional<Expr> shape_hint);
+TVM_DLL StructInfo StructInfoFromTypeLegacyShapeHint(const Type& type, Optional<Expr> shape_hint);
 
 /*!
  * \brief Get the corresponding legacy shape hint from struct info

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -211,17 +211,14 @@ class BlockBuilderImpl : public BlockBuilderNode {
     BlockFrame* cur_frame = CurrentFrame();
     Var var = CreateVar(cur_frame->is_dataflow, name_hint);
 
-    if (value->checked_type().as<ShapeTypeNode>()) {
-      UpdateType(var, ShapeType());
-    } else if (const DynTensorTypeNode* tty = value->checked_type().as<DynTensorTypeNode>()) {
-      ShapeExpr shape = ShapeExpr(pattern);
-      UpdateShape(var, shape);
-      DataType dtype = tty->dtype;
-      UpdateType(var, DynTensorType(pattern.size(), dtype));
+    if (value->struct_info_.as<ShapeStructInfoNode>()) {
+      UpdateStructInfo(var, ShapeStructInfo(pattern.size()));
+    } else if (const auto* tensor_sinfo = value->struct_info_.as<TensorStructInfoNode>()) {
+      UpdateStructInfo(var, TensorStructInfo(ShapeExpr(pattern), tensor_sinfo->dtype));
     } else {
       this->diag_ctx_.EmitFatal(
           Diagnostic::Error(value->span)
-          << "The value passed to EmitMatchShape must be of DynTensorType or ShapeType.");
+          << "The value passed to EmitMatchShape must be of TensorStructInfo or ShapeStructInfo.");
     }
 
     MatchShape match_shape = MatchShape(value, pattern, var);
@@ -348,8 +345,7 @@ class BlockBuilderImpl : public BlockBuilderNode {
     Var var = CreateVar(is_dataflow, name_hint);
 
     // set the values
-    UpdateType(var, expr->checked_type_);
-    UpdateShape(var, expr->shape_);
+    UpdateStructInfo(var, Downcast<StructInfo>(expr->struct_info_.value()));
 
     CurrentFrame()->bindings.push_back(VarBinding(var, expr));
 
@@ -474,7 +470,8 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
   Expr VisitVar_(const typename T::ContainerType* var) {
     // Parameters and free-vars must be present with struct info
     // Other vars must have already been normalized through binding
-    ICHECK(var->struct_info_.defined()) << "Var" << var << "does not have struct info";
+    ICHECK(var->struct_info_.defined())
+        << "Var " << var->name_hint() << " does not have struct info.";
     return GetRef<Var>(var);
   }
 
@@ -645,7 +642,7 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
     }
     // TODO(relax-team): provide additional context to EraseToWellDefined
     // such as variables defined by the parameters.
-    if (if_node->struct_info_.defined()) {
+    if (!if_node->struct_info_.defined()) {
       auto true_info = EraseToWellDefined(GetStructInfo(new_true));
       auto false_info = EraseToWellDefined(GetStructInfo(new_false));
       UpdateStructInfo(if_node, StructInfoLCA(true_info, false_info));
@@ -693,8 +690,7 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
     if (!new_value.same_as(binding->value)) {
       binding = MatchShape(new_value, binding->pattern, binding->var, binding->span);
     }
-    ICHECK(binding->var.defined());
-    if (!binding->var->struct_info_.defined()) {
+    if (binding->var.defined() && !binding->var->struct_info_.defined()) {
       UpdateStructInfo(binding->var, GetStructInfo(new_value));
     }
     return binding;

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#include <tvm/relax/analysis.h>
 #include <tvm/relax/expr.h>
 #include <tvm/relax/struct_info.h>
 #include <tvm/relax/type.h>
@@ -26,6 +27,12 @@ namespace tvm {
 RelayExpr RelayExprNode::shape() const {
   if (this->shape_.defined()) {
     return Downcast<RelayExpr>(this->shape_);
+  }
+  if (this->struct_info_.defined()) {
+    Optional<RelayExpr> shape = relax::GetLegacyShapeHint(Downcast<relax::StructInfo>(this->struct_info_.value()));
+    if (shape.defined()) {
+      return shape.value();
+    }
   }
   static const Op& op = Op::Get("relax.shape_of");
   RelayExpr self = GetRef<RelayExpr>(this);
@@ -98,10 +105,11 @@ TVM_REGISTER_NODE_TYPE(VarNode);
 Var::Var(Id vid, Optional<Expr> shape_annotation, Optional<Type> type_annotation, Span span) {
   ObjectPtr<VarNode> n = make_object<VarNode>();
   n->vid = std::move(vid);
-  n->shape_ = std::move(shape_annotation);
   if (type_annotation) {
+    n->struct_info_ = StructInfoFromTypeLegacyShapeHint(type_annotation.value(), shape_annotation);
     n->checked_type_ = std::move(type_annotation.value());
   }
+  n->shape_ = std::move(shape_annotation);
   n->span = std::move(span);
   data_ = std::move(n);
 }
@@ -296,6 +304,7 @@ ExternFunc::ExternFunc(String global_symbol, Span span) {
   n->global_symbol = std::move(global_symbol);
   n->span = span;
   n->checked_type_ = PackedFuncType();
+  n->struct_info_ = FuncStructInfo::OpaqueFunc();
   data_ = std::move(n);
 }
 

--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -56,8 +56,7 @@ bool EqualCheck(const PrimExpr& lhs, const PrimExpr& rhs);
       .set_num_inputs(2)                                                          \
       .add_argument("lhs", "Tensor", "The left hand side tensor.")                \
       .add_argument("rhs", "Tensor", "The right hand side tensor.")               \
-      .set_attr<FInferShape>("FInferShape", InferShapeBinaryBroadcast)            \
-      .set_attr<FInferType>("FInferType", InferTypeBinaryBroadcast)
+      .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoBroadcast)   \
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/binary.cc
+++ b/src/relax/op/tensor/binary.cc
@@ -35,23 +35,64 @@ RELAX_REGISTER_BINARY_BROADCAST_OP("multiply")
     .describe("Elementwise multiply with broadcasting")
     .set_support_level(1);
 
-Expr InferShapeBinaryBroadcast(const Call& call, DiagnosticContext diag_ctx) {
+StructInfo InferStructInfoBroadcast(const Call& call, const BlockBuilder& ctx) {
   if (call->args.size() != 2) {
-    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
-                       << "Binary broadcast op should have 2 arguments");
+    ctx->ReportFatal(Diagnostic::Error(call->span)
+                     << "Binary broadcast op should have 2 arguments");
   }
-  Expr lhs_shape = call->args[0]->shape();
-  Expr rhs_shape = call->args[1]->shape();
-  auto* s0 = lhs_shape.as<ShapeExprNode>();
-  auto* s1 = rhs_shape.as<ShapeExprNode>();
-  if (s0 && s1) {
+  auto _lhs_sinfo = MatchStructInfo<TensorStructInfo>(call->args[0]);
+  auto _rhs_sinfo = MatchStructInfo<TensorStructInfo>(call->args[1]);
+  if (!_lhs_sinfo || !_rhs_sinfo) {
+    ctx->ReportFatal(Diagnostic::Error(call->span)
+                     << "Both lhs and rhs should be Tensor for broadcasting, but got "
+                     << call->args[0]->struct_info_->GetTypeKey() << " and "
+                     << call->args[0]->struct_info_->GetTypeKey());
+  }
+
+  // DateType
+  DataType output_dtype;
+  TensorStructInfo lhs_sinfo = _lhs_sinfo.value();
+  TensorStructInfo rhs_sinfo = _rhs_sinfo.value();
+  if (lhs_sinfo->IsUnknownDtype() || rhs_sinfo->IsUnknownDtype()) {
+    output_dtype = DataType::Void();
+  } else if (lhs_sinfo->dtype != rhs_sinfo->dtype) {
+    ctx->ReportFatal(Diagnostic::Error(call->span)
+                     << "Data types " << lhs_sinfo->dtype << " and " << rhs_sinfo->dtype
+                     << " must be equal for broadcasting operators");
+  } else {
+    output_dtype = lhs_sinfo->dtype;
+  }
+
+  // ndims
+  int output_ndim;
+  if (lhs_sinfo->IsUnknownNdim() || rhs_sinfo->IsUnknownNdim()) {
+    output_ndim = kUnknownDim;
+  } else {
+    output_ndim = std::max(lhs_sinfo->ndim, rhs_sinfo->ndim);
+  }
+
+  // Shapes and ndims
+  if (lhs_sinfo->shape && rhs_sinfo->shape) {
+    // If all inputs have shapes, directly infer shapes
     std::vector<PrimExpr> output_shape;
-    size_t ndim0 = s0->values.size();
-    size_t ndim1 = s1->values.size();
+
+    auto check_shape_expr = [&](const Expr& shape) -> const ShapeExprNode* {
+      if (const auto* shape_expr = shape.as<ShapeExprNode>()) {
+        return shape_expr;
+      } else {
+        ctx->ReportFatal(Diagnostic::Error(call->span)
+                         << "Shapes are expected to be ShapeExpr, but got: " << shape << ".");
+        return nullptr;
+      }
+    };
+    const ShapeExprNode* lhs_shape = check_shape_expr(lhs_sinfo->shape.value());
+    const ShapeExprNode* rhs_shape = check_shape_expr(rhs_sinfo->shape.value());
+    size_t lhs_ndim = lhs_sinfo->ndim;
+    size_t rhs_ndim = rhs_sinfo->ndim;
     size_t i = 1;
-    for (; i <= std::min(ndim0, ndim1); ++i) {
-      PrimExpr dim0 = s0->values[ndim0 - i];
-      PrimExpr dim1 = s1->values[ndim1 - i];
+    for (; i <= std::min(lhs_ndim, rhs_ndim); ++i) {
+      const PrimExpr& dim0 = lhs_shape->values[lhs_ndim - i];
+      const PrimExpr& dim1 = rhs_shape->values[rhs_ndim - i];
       if (EqualConstInt(dim0, 1)) {
         output_shape.push_back(dim1);
       } else if (EqualConstInt(dim1, 1)) {
@@ -59,57 +100,26 @@ Expr InferShapeBinaryBroadcast(const Call& call, DiagnosticContext diag_ctx) {
       } else if (EqualCheck(dim0, dim1)) {
         output_shape.push_back(dim0);
       } else {
+        // TODO(Siyuan): use "binary_broadcast_shape_infer"
+        return TensorStructInfo(output_dtype, /*ndim=*/output_ndim);
         // defer the computation of output shapes to runtime
         // e.g., broadcast Tensor([m, n]), Tensor([k]) -> defer to runtime
-        Call call_infer(ExternFunc(String("vm.binary_broadcast_shape_infer")),
-                        {call->args[0], call->args[1]}, {}, {});
-        call_infer->checked_type_ = ShapeType();
-        return call_infer;
+        // Call call_infer(ExternFunc(String("vm.binary_broadcast_shape_infer")),
+        //                 {call->args[0], call->args[1]}, {}, {});
+        // call_infer->checked_type_ = ShapeType();
+        // return call_infer;
       }
     }
-    size_t max_ndim = std::max(ndim0, ndim1);
-    auto& longer_shape = (ndim0 > ndim1) ? s0 : s1;
+    size_t max_ndim = std::max(lhs_ndim, rhs_ndim);
+    auto& longer_shape = (lhs_ndim > rhs_ndim) ? lhs_shape : rhs_shape;
     for (; i <= max_ndim; ++i) {
       output_shape.push_back(longer_shape->values[max_ndim - i]);
     }
-    return ShapeExpr(Array<PrimExpr>(output_shape.rbegin(), output_shape.rend()));
-  }
-  return RuntimeDepShape();
-}
-
-Type InferTypeBinaryBroadcast(const Call& call, DiagnosticContext diag_ctx) {
-  if (call->args.size() != 2) {
-    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
-                       << "Binary broadcast op should have 2 arguments");
-  }
-  Type lhs_type = call->args[0]->checked_type();
-  Type rhs_type = call->args[1]->checked_type();
-  auto* t0 = lhs_type.as<DynTensorTypeNode>();
-  auto* t1 = rhs_type.as<DynTensorTypeNode>();
-  if (!t0 || !t1) {
-    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
-                       << "Both lhs and rhs should be DynTensor for broadcasting, but got "
-                       << lhs_type->GetTypeKey() << " and " << rhs_type->GetTypeKey());
-  }
-
-  DataType output_dtype;
-  if (t0->IsUnknownDtype() || t1->IsUnknownDtype()) {
-    output_dtype = DataType::Void();
-  } else if (t0->dtype != t1->dtype) {
-    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
-                       << "Data types " << t0->dtype << " and " << t1->dtype
-                       << " must be equal for broadcasting operators");
+    Expr shape = ShapeExpr(Array<PrimExpr>(output_shape.rbegin(), output_shape.rend()));
+    return TensorStructInfo(shape, output_dtype);
   } else {
-    output_dtype = t0->dtype;
+    return TensorStructInfo(output_dtype, /*ndim=*/output_ndim);
   }
-
-  int output_ndim;
-  if (t0->IsUnknownNdim() || t1->IsUnknownNdim()) {
-    output_ndim = -1;
-  } else {
-    output_ndim = std::max(t0->ndim, t1->ndim);
-  }
-  return DynTensorType(output_ndim, output_dtype);
 }
 
 }  // namespace relax

--- a/src/relax/op/tensor/binary.h
+++ b/src/relax/op/tensor/binary.h
@@ -36,8 +36,7 @@
 namespace tvm {
 namespace relax {
 
-Type InferTypeBinaryBroadcast(const Call& call, DiagnosticContext diag_ctx);
-Expr InferShapeBinaryBroadcast(const Call& call, DiagnosticContext diag_ctx);
+StructInfo InferStructInfoBroadcast(const Call& call, const BlockBuilder& ctx);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/unary.cc
+++ b/src/relax/op/tensor/unary.cc
@@ -41,7 +41,7 @@ Expr MakeUnique(Expr data, bool sorted, bool return_inverse, bool return_counts,
 
 TVM_REGISTER_GLOBAL("relax.op.unique").set_body_typed(MakeUnique);
 
-StructInfo InferStructInfoUnique(const Call& call, const BlockBuilder ctx) {
+StructInfo InferStructInfoUnique(const Call& call, const BlockBuilder& ctx) {
   if (call->args.size() != 1) {
     ctx->ReportFatal(Diagnostic::Error(call->span) << "Unique op should have 1 argument");
   }

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -346,9 +346,13 @@ def test_normalize():
     bb.normalize(tuple_1)
     assert_structural_equal(tuple_1.checked_type, rx.TupleType([type_anno0, type_anno1]))
     assert_structural_equal(tuple_1.shape, rx.Tuple([x.shape, y.shape]))
-    assert_structural_equal(
-        tuple_1.shape.checked_type, rx.TupleType([rx.ShapeType(), rx.ShapeType()])
-    )
+    assert isinstance(tuple_1.struct_info, rx.TupleStructInfo)
+    assert isinstance(tuple_1.struct_info.fields[0], rx.TensorStructInfo)
+    assert isinstance(tuple_1.struct_info.fields[1], rx.TensorStructInfo)
+    # Note sure if it's needed
+    # assert_structural_equal(
+    #     tuple_1.shape.checked_type, rx.TupleType([rx.ShapeType(), rx.ShapeType()])
+    # )
 
     # Nested Tuple
     tuple_2 = rx.Tuple([x, rx.Tuple([x, y])])
@@ -357,10 +361,15 @@ def test_normalize():
         tuple_2.checked_type, rx.TupleType([type_anno0, rx.TupleType([type_anno0, type_anno1])])
     )
     assert_structural_equal(tuple_2.shape, rx.Tuple([x.shape, rx.Tuple([x.shape, y.shape])]))
-    assert_structural_equal(
-        tuple_2.shape.checked_type,
-        rx.TupleType([rx.ShapeType(), rx.TupleType([rx.ShapeType(), rx.ShapeType()])]),
-    )
+    assert isinstance(tuple_2.struct_info, rx.TupleStructInfo)
+    assert isinstance(tuple_2.struct_info.fields[0], rx.TensorStructInfo)
+    assert isinstance(tuple_2.struct_info.fields[1], rx.TupleStructInfo)
+    assert isinstance(tuple_2.struct_info.fields[1].fields[0], rx.TensorStructInfo)
+    assert isinstance(tuple_2.struct_info.fields[1].fields[1], rx.TensorStructInfo)
+    # assert_structural_equal(
+    #     tuple_2.shape.checked_type,
+    #     rx.TupleType([rx.ShapeType(), rx.TupleType([rx.ShapeType(), rx.ShapeType()])]),
+    # )
 
 
 def test_call_te():

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -495,7 +495,7 @@ def test_annotation():
     )
     _check_type_shape(bindings[1], relax.DynTensorType(dtype=""), None)
     _check_type_shape(bindings[2], relax.DynTensorType(ndim=2, dtype=""), None)
-    _check_type_shape(bindings[3], relax.DynTensorType(dtype=""), RuntimeDepShape())
+    _check_type_shape(bindings[3], relax.DynTensorType(dtype=""), None)
     _check_type_shape(bindings[4], relax.ShapeType(), None)
     _check_type_shape(
         bindings[5],


### PR DESCRIPTION
Some misc fixes about the struct info deduction.

Known issue:
1. local function's sinfo
2. sinfo of `ExternFuncNode`(i.e. `R.call_packed`)