### PR TITLE
Remove `match_shape`

### DIFF
--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -160,15 +160,6 @@ class BlockBuilderNode : public Object {
   virtual Var Emit(Expr expr, String name_hint = "") = 0;
 
   /*!
-   * \brief Emit a MatchShape.
-   * \param value The value of the MatchShape to be emitted.
-   * \param pattern The pattern of the MatchShape to be emitted.
-   * \param name_hint Name hint for the bound variable.
-   * \return The variable bound to the MatchShape.
-   */
-  virtual Var EmitMatchShape(Expr value, Array<PrimExpr> pattern, String name_hint = "") = 0;
-
-  /*!
    * \brief Emit a MatchCast.
    * \param value The input value.
    * \param struct_info The struct info to be matched.

--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -531,11 +531,26 @@ class Constant : public Expr {
 /*! \brief The base class of a variable binding in Relax. */
 class BindingNode : public Object {
  public:
+  /*! \brief The return variable to bound to. */
+  Var var;
+  /*! \brief The binding value. */
+  Expr value;
+
   mutable Span span;
 
-  void VisitAttrs(AttrVisitor* v) { v->Visit("span", &span); }
-  bool SEqualReduce(const BindingNode* other, SEqualReducer equal) const { return true; }
-  void SHashReduce(SHashReducer hash_reduce) const {}
+  void VisitAttrs(AttrVisitor* v) {
+    v->Visit("var", &var);
+    v->Visit("value", &value);
+    v->Visit("span", &span);
+  }
+
+  bool SEqualReduce(const BindingNode* other, SEqualReducer equal) const {
+    return equal.DefEqual(var, other->var) && equal(value, other->value);
+  }
+  void SHashReduce(SHashReducer hash_reduce) const {
+    hash_reduce.DefHash(var);
+    hash_reduce(value);
+  }
 
   static constexpr const char* _type_key = "relax.expr.Binding";
   static constexpr const bool _type_has_method_sequal_reduce = true;
@@ -555,46 +570,6 @@ class Binding : public ObjectRef {
   using ContainerType = BindingNode;
 };
 
-/*! \brief Symbolic shape match, binds the variable of the lhs with the rhs. */
-class MatchShapeNode : public BindingNode {
- public:
-  Expr value;
-  Array<PrimExpr> pattern;
-  Var var;
-
-  void VisitAttrs(AttrVisitor* v) {
-    v->Visit("value", &value);
-    v->Visit("pattern", &pattern);
-    v->Visit("var", &var);
-    v->Visit("span", &span);
-  }
-
-  bool SEqualReduce(const MatchShapeNode* other, SEqualReducer equal) const {
-    // NOTE: pattern can contain ShapeExpr which defines the vars
-    return equal(value, other->value) && equal.DefEqual(pattern, other->pattern) &&
-           equal.DefEqual(var, other->var);
-  }
-
-  void SHashReduce(SHashReducer hash_reduce) const {
-    // NOTE: pattern can contain ShapeExpr which defines the vars
-    hash_reduce(value);
-    hash_reduce.DefHash(pattern);
-    hash_reduce.DefHash(var);
-  }
-
-  static constexpr const char* _type_key = "relax.expr.MatchShape";
-  static constexpr const bool _type_has_method_sequal_reduce = true;
-  static constexpr const bool _type_has_method_shash_reduce = true;
-  TVM_DECLARE_FINAL_OBJECT_INFO(MatchShapeNode, BindingNode);
-};
-
-class MatchShape : public Binding {
- public:
-  TVM_DLL explicit MatchShape(Expr value, Array<PrimExpr> pattern, Var var, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(MatchShape, Binding, MatchShapeNode);
-  TVM_DEFINE_OBJECT_REF_COW_METHOD(MatchShapeNode);
-};
-
 /*!
  * \brief Runtime-match the value to the struct info.
  *
@@ -604,10 +579,6 @@ class MatchShape : public Binding {
  */
 class MatchCastNode : public BindingNode {
  public:
-  /*! \brief The return variable to bound to. */
-  Var var;
-  /*! \brief The input value. */
-  Expr value;
   /*! \brief The struct info pattern to match to. */
   StructInfo struct_info;
 
@@ -651,9 +622,6 @@ class MatchCast : public Binding {
 
 class VarBindingNode : public BindingNode {
  public:
-  Var var;
-  Expr value;
-
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("var", &var);
     v->Visit("value", &value);
@@ -679,7 +647,6 @@ class VarBinding : public Binding {
   TVM_DEFINE_OBJECT_REF_METHODS(VarBinding, Binding, VarBindingNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(VarBindingNode);
 };
-
 
 class BindingBlockNode : public Object {
  public:

--- a/include/tvm/relax/ir_functor.h
+++ b/include/tvm/relax/ir_functor.h
@@ -77,7 +77,6 @@ class IRFunctor<R(const ObjectRef& n, Args...)> {
   virtual R VisitNode_(const relax::VarNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::DataflowVarNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::ShapeExprNode* op, Args... args) IR_FUNCTOR_DEFAULT;
-  virtual R VisitNode_(const relax::MatchShapeNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::MatchCastNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::VarBindingNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::BindingBlockNode* op, Args... args) IR_FUNCTOR_DEFAULT;
@@ -104,7 +103,6 @@ class IRFunctor<R(const ObjectRef& n, Args...)> {
     RELAX_IR_FUNCTOR_DISPATCH(relax::VarNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::DataflowVarNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::ShapeExprNode);
-    RELAX_IR_FUNCTOR_DISPATCH(relax::MatchShapeNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::MatchCastNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::VarBindingNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::BindingBlockNode);

--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -111,15 +111,13 @@ TVM_DLL void DataflowBlockOutput(const Array<tvm::relax::Var>& vars);
 TVM_DLL tvm::relax::Var Emit(const tvm::relax::Expr& value);
 
 /*!
- * \brief Emit a match_shape binding to the last binding block frame.
- * \param value The value of the MatchShape to be emitted.
- * \param pattern The pattern of the MatchShape to be emitted.
- * \param emit_var A boolean indicating if the MatchShape contains the emitted variable.
- * \return The emitted var if `emit_var` is true. Otherwise, return `NullOpt`.
+ * \brief Emit a match_cast binding to the last binding block frame.
+ * \param value The value of the MatchCast to be emitted.
+ * \param struct_info The struct info of the MatchCast to be emitted.
+ * \return The left side var of the emitted binding.
  */
-TVM_DLL Optional<tvm::relax::Var> EmitMatchShape(const tvm::relax::Expr& value,   //
-                                                 const Array<PrimExpr>& pattern,  //
-                                                 bool emit_var);
+TVM_DLL tvm::relax::Var EmitMatchCast(const tvm::relax::Expr& value,
+                                      const tvm::relax::StructInfo& struct_info);
 
 ///////////////////////////// Type Deduce //////////////////////////////
 

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -38,7 +38,7 @@ from .expr import (
     Var,
     DataflowVar,
     Binding,
-    MatchShape,
+    MatchCast,
     VarBinding,
     BindingBlock,
     DataflowBlock,

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -541,31 +541,13 @@ class BlockBuilder(Object):
         """
         return self.emit(self.call_te(func, *args, **kwargs))
 
-    def match_shape(self, value: Expr, pattern: List[PrimExpr]) -> Var:
-        """Emit a MatchShape.
-
-        Parameters
-        ----------
-        value : tvm.relax.Expr
-            The value of the MatchShape to be emitted.
-
-        pattern : List[PrimExpr]
-            The pattern of the MatchShape to be emitted.
-
-        Returns
-        -------
-        ret : tvm.relax.Var
-            A newly created variable that gets bound to the call code.
-        """
-        return _ffi_api.BlockBuilderEmitMatchShape(self, value, pattern)  # type: ignore
-
     def match_cast(self, value: Expr, struct_info: StructInfo) -> Var:
         """Emit a MatchCast.
 
         Parameters
         ----------
         value : tvm.relax.Expr
-            The value of the MatchShape to be emitted.
+            The value of the MatchCast to be emitted.
 
         struct_info : StructInfo
             The struct info to be matched.

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -308,20 +308,6 @@ class Binding(Node):
     ...
 
 
-@tvm._ffi.register_object("relax.expr.MatchShape")
-class MatchShape(Binding):
-    """Symbolic shape match, binds the variable of the lhs with the rhs."""
-
-    value: Expr
-    pattern: List[PrimExpr]
-    var: Var
-
-    def __init__(self, value: Expr, pattern: List[PrimExpr], var: Var, span: Span = None) -> None:
-        self.__init_handle_by_constructor__(
-            _ffi_api.MatchShape, value, pattern, var, span  # type: ignore
-        )
-
-
 @tvm._ffi.register_object("relax.expr.MatchCast")
 class MatchCast(Binding):
     """Runtime-match the value to the struct info.
@@ -335,24 +321,22 @@ class MatchCast(Binding):
     var: Var
         The return variable that the match cast bind to.
 
-    struct_info: tvm.relax.StructInfo
-        The struct info to match cast to.
-
     value: Expr
         The input value expression.
+
+    struct_info: tvm.relax.StructInfo
+        The struct info to match cast to.
     """
 
     var: Var
     struct_info: "tvm.relax.StructInfo"
     value: Expr
 
-    def __init__(self,
-                 var: Var,
-                 struct_info: "tvm.relax.StructInfo",
-                 value: Expr,
-                 span: Span = None) -> None:
+    def __init__(
+        self, var: Var, value: Expr, struct_info: "tvm.relax.StructInfo", span: Span = None
+    ) -> None:
         self.__init_handle_by_constructor__(
-            _ffi_api.MatchCast, var, struct_info, value, span  # type: ignore
+            _ffi_api.MatchCast, var, value, struct_info, span  # type: ignore
         )
 
 

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -29,7 +29,7 @@ from .expr import Constant, Var, DataflowVar
 from .expr import ShapeExpr
 from .expr import GlobalVar, SeqExpr, Tuple
 from .expr import Call, If, TupleGetItem
-from .expr import Binding, MatchShape, VarBinding
+from .expr import Binding, MatchCast, VarBinding
 from .expr import BindingBlock, DataflowBlock
 from .struct_info import StructInfo
 from ..relay import Id
@@ -190,7 +190,7 @@ class ExprFunctor:
     def visit_var_binding_(self, binding: VarBinding):
         raise NotImplementedError()
 
-    def visit_match_shape_(self, binding: MatchShape):
+    def visit_match_cast_(self, binding: MatchCast):
         raise NotImplementedError()
 
     def visit_binding_block_(self, block: BindingBlock):
@@ -206,8 +206,8 @@ class ExprFunctor:
         raise NotImplementedError()
 
     def visit_binding(self, binding: Binding):
-        if isinstance(binding, MatchShape):
-            self.visit_match_shape_(binding)
+        if isinstance(binding, MatchCast):
+            self.visit_match_cast_(binding)
         elif isinstance(binding, VarBinding):
             self.visit_var_binding_(binding)
         else:
@@ -259,7 +259,7 @@ class _PyExprVisitor(Object):
         f_visit_tuple_getitem_: Callable = None,
         f_visit_binding: Callable = None,
         f_visit_var_binding_: Callable = None,
-        f_visit_match_shape_: Callable = None,
+        f_visit_match_cast_: Callable = None,
         f_visit_binding_block: Callable = None,
         f_visit_binding_block_: Callable = None,
         f_visit_dataflow_block_: Callable = None,
@@ -289,7 +289,7 @@ class _PyExprVisitor(Object):
             f_visit_tuple_getitem_,
             f_visit_binding,
             f_visit_var_binding_,
-            f_visit_match_shape_,
+            f_visit_match_cast_,
             f_visit_binding_block,
             f_visit_binding_block_,
             f_visit_dataflow_block_,
@@ -378,7 +378,7 @@ class PyExprVisitor:
             "visit_tuple_getitem_",
             "visit_binding",
             "visit_var_binding_",
-            "visit_match_shape_",
+            "visit_match_cast_",
             "visit_binding_block",
             "visit_binding_block_",
             "visit_dataflow_block_",
@@ -623,15 +623,15 @@ class PyExprVisitor:
         # Using self._outer() to ref _PyExprVisitor
         return _ffi_api.ExprVisitorVisitBinding(self._outer(), binding)  # type: ignore
 
-    def visit_match_shape_(self, binding: MatchShape) -> None:
-        """Visit MatchShape.
-        Users can customized this function to overwrite VisitBinding_(const MatchShapeNode* binding)
+    def visit_match_cast_(self, binding: MatchCast) -> None:
+        """Visit MatchCast.
+        Users can customized this function to overwrite VisitBinding_(const MatchCastNode* binding)
         on the C++ side.
 
         Parameters
         ----------
-        binding : MatchShape
-            The MatchShape to be visited.
+        binding : MatchCast
+            The MatchCast to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
         return _ffi_api.ExprVisitorVisitBinding(self._outer(), binding)  # type: ignore
@@ -743,7 +743,7 @@ class _PyExprMutator(Object):
         f_visit_tuple_getitem_: Callable = None,
         f_visit_binding: Callable = None,
         f_visit_var_binding_: Callable = None,
-        f_visit_match_shape_: Callable = None,
+        f_visit_match_cast_: Callable = None,
         f_visit_binding_block: Callable = None,
         f_visit_binding_block_: Callable = None,
         f_visit_dataflow_block_: Callable = None,
@@ -774,7 +774,7 @@ class _PyExprMutator(Object):
             f_visit_tuple_getitem_,
             f_visit_binding,
             f_visit_var_binding_,
-            f_visit_match_shape_,
+            f_visit_match_cast_,
             f_visit_binding_block,
             f_visit_binding_block_,
             f_visit_dataflow_block_,
@@ -879,7 +879,7 @@ class PyExprMutator:
             "visit_tuple_getitem_",
             "visit_binding",
             "visit_var_binding_",
-            "visit_match_shape_",
+            "visit_match_cast_",
             "visit_binding_block",
             "visit_binding_block_",
             "visit_dataflow_block_",
@@ -1208,15 +1208,15 @@ class PyExprMutator:
         # Using self._outer() to ref _PyExprMutator
         return _ffi_api.ExprMutatorVisitBinding(self._outer(), binding)  # type: ignore
 
-    def visit_match_shape_(self, binding: MatchShape) -> None:
-        """Visit MatchShape.
-        Users can customized this function to overwrite VisitBinding_(const MatchShapeNode* binding)
+    def visit_match_cast_(self, binding: MatchCast) -> None:
+        """Visit MatchCast.
+        Users can customized this function to overwrite VisitBinding_(const MatchCastNode* binding)
         on the C++ side.
 
         Parameters
         ----------
-        binding : MatchShape
-            The MatchShape to be visited.
+        binding : MatchCast
+            The MatchCast to be visited.
         """
         # Using self._outer() to ref _PyExprMutator
         return _ffi_api.ExprMutatorVisitBinding(self._outer(), binding)  # type: ignore

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -312,24 +312,22 @@ class ASTPrinter(ExprFunctor):
         """
         Distinguish between binding types
         """
-        if isinstance(binding, relax.MatchShape):
-            return self.visit_match_shape_(binding)
+        if isinstance(binding, relax.MatchCast):
+            return self.visit_match_cast_(binding)
         if isinstance(binding, relax.VarBinding):
             return self.visit_var_binding_(binding)
         raise ValueError(f"Invalid binding type in {binding}: {type(binding)}")
 
-    def visit_match_shape_(self, match_shape: relax.MatchShape) -> str:
+    def visit_match_cast_(self, match_cast: relax.MatchCast) -> str:
         """
         Handle match shape
         """
         fields = {
-            "value": self.visit_expr(match_shape.value),
-            "pattern": self.build_list(map(self.visit_prim_expr_, match_shape.pattern)),
+            "var": self.visit_expr(match_cast.var),
+            "value": self.visit_expr(match_cast.value),
+            "struct_info": self.visit_struct_info_(match_cast.struct_info),
         }
-        # not always defined
-        if match_shape.var:
-            fields["var"] = self.visit_expr(match_shape.var)
-        return self.build_ast_node("MatchShape", **fields)
+        return self.build_ast_node("MatchCast", **fields)
 
     def visit_var_binding_(self, var_binding: relax.VarBinding) -> str:
         """

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -281,25 +281,6 @@ def emit(value: Expr) -> Var:
     return _ffi_api.Emit(value)  # pylint: disable=no-member # type: ignore
 
 
-def emit_match_shape(value: Expr, pattern: List[PrimExpr], emit_var: bool) -> Optional[Var]:
-    """Emit a match_shape binding to the last binding block frame.
-    Parameters
-    ----------
-    value: Expr
-        The value of the MatchShape to be emitted.
-    pattern: List[PrimExpr]
-        The pattern of the MatchShape to be emitted.
-    emit_var: bool
-        A boolean indicating if the MatchShape contains the emitted variable.
-
-    Returns
-    -------
-    var: Optional[Var]
-        The emitted var if `emit_var` is True. Otherwise, return `None`.
-    """
-    return _ffi_api.EmitMatchShape(value, pattern, emit_var)  # type: ignore
-
-
 def emit_match_cast(value: Expr, struct_info: StructInfo) -> Var:
     """Emit a match_cast binding to the last binding block frame.
     Parameters
@@ -425,7 +406,6 @@ __all__ = [
     "dataflow",
     "emit",
     "emit_match_cast",
-    "emit_match_shape",
     "ewise_fma",
     "func_attr",
     "func_name",

--- a/python/tvm/script/parser/relax/__init__.py
+++ b/python/tvm/script/parser/relax/__init__.py
@@ -18,7 +18,7 @@
 from ...ir_builder.relax import *  # pylint: disable=redefined-builtin
 from ...ir_builder.relax import ir as _relax
 from . import parser as _parser
-from .entry import Callable, Shape, Tensor, Tuple, function, match_cast, match_shape
+from .entry import Callable, Shape, Tensor, Tuple, function, match_cast
 
 __all__ = _relax.__all__ + [
     "Callable",
@@ -27,5 +27,4 @@ __all__ = _relax.__all__ + [
     "Tuple",
     "function",
     "match_cast",
-    "match_shape",
 ]

--- a/python/tvm/script/parser/relax/entry.py
+++ b/python/tvm/script/parser/relax/entry.py
@@ -177,23 +177,6 @@ class ShapeProxy:
 
 Shape = ShapeProxy()
 
-############################ R.match_shape #############################
-class MatchShapePair:
-    value: Expr
-    pattern: List[PrimExpr]
-
-    def __init__(self, value: Expr, pattern: List[PrimExpr]) -> None:
-        self.value = value
-        self.pattern = pattern
-
-
-def match_shape(value: Expr, pattern: List[PrimExpr]):
-    if value is None:
-        raise ValueError("value of match_shape cannot be None")
-    if pattern is None:
-        raise ValueError("pattern of match_shape cannot be None")
-    return MatchShapePair(value, pattern)
-
 
 ############################ R.match_cast #############################
 class MatchCastPair:

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -29,7 +29,7 @@ from ...ir_builder import ir as I
 from ...ir_builder import relax as R
 from ...ir_builder.base import IRBuilder
 from .._core import Parser, dispatch, doc
-from .entry import MatchShapePair, MatchCastPair
+from .entry import MatchCastPair
 
 
 def bind_assign_value(self: Parser, node: doc.expr, var_name: str, value: Any) -> Any:
@@ -66,12 +66,6 @@ def bind_assign_value(self: Parser, node: doc.expr, var_name: str, value: Any) -
         value = R.const(value)
     if isinstance(value, relax.Expr):
         var = R.emit(value)
-        # It's an internal check, so directly use assert here.
-        assert var is not None
-        IRBuilder.name(var_name, var)
-        return var
-    elif isinstance(value, MatchShapePair):
-        var = R.emit_match_shape(value.value, value.pattern, emit_var=True)
         # It's an internal check, so directly use assert here.
         assert var is not None
         IRBuilder.name(var_name, var)
@@ -154,9 +148,7 @@ def post_token_switch(self: Parser, node: doc.Expr) -> None:
 @dispatch.register(token="relax", type_name="Expr")
 def visit_expr_stmt(self: Parser, node: doc.Expr) -> None:
     value = self.eval_expr(node.value)
-    if isinstance(value, MatchShapePair):
-        R.emit_match_shape(value.value, value.pattern, emit_var=False)
-    elif value is not None:
+    if value is not None:
         self.report_error(node, f"Unsupported Expr stmt type {value}.")
 
 

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -262,22 +262,6 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::ShapeExprNode* op) {
   return doc;
 }
 
-Doc RelaxScriptPrinter::VisitNode_(const relax::MatchShapeNode* op) {
-  Doc doc;
-  if (op->var.defined()) {
-    doc << Print(op->var);
-    if (const auto& sinfo = MatchStructInfo<StructInfo>(op->var)) {
-      doc << ": " << Print(sinfo);
-    }
-    doc << " = ";
-  }
-  doc << "R.match_shape(";
-  // TODO(@altanh): maybe op->pattern should just be a ShapeExpr?
-  doc << Print(op->value) << ", " << Print(relax::ShapeExpr(op->pattern));
-  doc << ")";
-  return doc;
-}
-
 Doc RelaxScriptPrinter::VisitNode_(const relax::MatchCastNode* op) {
   Doc doc;
   doc << Print(op->var);
@@ -331,16 +315,7 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::DataflowBlockNode* op) {
   std::vector<Doc> return_vars;
   for (const relax::Binding& binding : op->bindings) {
     body << Print(binding) << Doc::NewLine();
-    Var var;
-    if (const auto* var_binding = binding.as<VarBindingNode>()) {
-      var = var_binding->var;
-    } else if (const auto* shape_binding = binding.as<MatchShapeNode>()) {
-      var = shape_binding->var;
-    } else if (const auto* match_cast = binding.as<MatchCastNode>()) {
-      var = match_cast->var;
-    } else {
-      LOG(FATAL) << "Unsupported binding type: " << binding->GetTypeKey();
-    }
+    Var var = binding->var;
     if (var.defined() && !var.as<relax::DataflowVarNode>()) {
       return_vars.push_back(Print(var));
     }

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -279,7 +279,6 @@ class RelaxScriptPrinter : public relax::IRFunctor<Doc(const ObjectRef&)>,
   Doc VisitNode_(const relax::VarNode* op) override;
   Doc VisitNode_(const relax::DataflowVarNode* op) override;
   Doc VisitNode_(const relax::ShapeExprNode* op) override;
-  Doc VisitNode_(const relax::MatchShapeNode* op) override;
   Doc VisitNode_(const relax::MatchCastNode* op) override;
   Doc VisitNode_(const relax::VarBindingNode* op) override;
   Doc VisitNode_(const relax::BindingBlockNode* op) override;

--- a/src/relax/analysis/analysis.cc
+++ b/src/relax/analysis/analysis.cc
@@ -134,13 +134,6 @@ class VarVisitor : protected ExprVisitor {
     VisitVarDef(binding->var);
   }
 
-  void VisitBinding_(const MatchShapeNode* binding) final {
-    if (binding->var.defined()) {
-      MarkBounded(binding->var);
-    }
-    ExprVisitor::VisitBinding_(binding);
-  }
-
   void VisitBinding_(const MatchCastNode* binding) final {
     MarkBounded(binding->var);
     ExprVisitor::VisitBinding_(binding);

--- a/src/relax/analysis/var2value.cc
+++ b/src/relax/analysis/var2value.cc
@@ -70,11 +70,6 @@ class Name2BindingAnalysis : public relax::ExprVisitor {
     name2bindings_[vname].push_back(GetRef<VarBinding>(binding));
   }
 
-  void VisitBinding_(const MatchShapeNode* binding) override {
-    const auto& vname = binding->var->name_hint();
-    name2bindings_[vname].push_back(GetRef<MatchShape>(binding));
-  }
-
   void VisitBinding_(const MatchCastNode* binding) override {
     const auto& vname = binding->var->name_hint();
     name2bindings_[vname].push_back(GetRef<MatchCast>(binding));

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -269,24 +269,6 @@ class WellFormedChecker : public relax::ExprVisitor,
     this->VisitVarDef(binding->var);
   }
 
-  void VisitBinding_(const MatchShapeNode* binding) {
-    this->VisitExpr(binding->value);
-    // define the vars
-    WithMode(VisitMode::kMatchVarDef, [&]() {
-      for (PrimExpr expr : binding->pattern) {
-        this->VisitStructInfoExprField(expr);
-      }
-    });
-
-    for (PrimExpr expr : binding->pattern) {
-      this->VisitStructInfoExprField(expr);
-    }
-
-    if (binding->var.defined()) {
-      this->VisitVarDef(binding->var);
-    }
-  }
-
   void VisitBinding_(const MatchCastNode* binding) {
     this->VisitExpr(binding->value);
     // define the vars

--- a/src/relax/backend/contrib/codegen_json/codegen_json.h
+++ b/src/relax/backend/contrib/codegen_json/codegen_json.h
@@ -252,11 +252,6 @@ class JSONSerializer
     return VisitExpr(binding->value);
   }
 
-  std::vector<JSONGraphNodeEntry> VisitBinding_(const MatchShapeNode* binding) {
-    LOG(FATAL) << "JSON runtime currently doesn't shape expr\n";
-    return {};
-  }
-
   std::vector<JSONGraphNodeEntry> VisitBinding_(const MatchCastNode* binding) {
     LOG(FATAL) << "JSON runtime currently doesn't match cast\n";
     return {};
@@ -267,7 +262,7 @@ class JSONSerializer
     if (const auto* node = binding.as<VarBindingNode>()) {
       auto from_b = VisitBinding_(node);
       nodes.insert(nodes.end(), from_b.begin(), from_b.end());
-    } else if (const auto* node = binding.as<MatchShapeNode>()) {
+    } else if (const auto* node = binding.as<MatchCastNode>()) {
       auto from_b = VisitBinding_(node);
       nodes.insert(nodes.end(), from_b.begin(), from_b.end());
     } else {

--- a/src/relax/backend/contrib/codegen_json/codegen_json.h
+++ b/src/relax/backend/contrib/codegen_json/codegen_json.h
@@ -27,6 +27,7 @@
 #include <dmlc/any.h>
 #include <dmlc/json.h>
 #include <tvm/node/reflection.h>
+#include <tvm/relax/struct_info.h>
 #include <tvm/tir/op.h>
 
 #include <cstdint>
@@ -187,7 +188,7 @@ class JSONSerializer
    *         will flatten it.
    */
   std::vector<JSONGraphNodeEntry> AddNode(JSONGraphObjectPtr node, const Expr& expr) {
-    auto checked_type = expr->checked_type();
+    auto struct_info = GetStructInfo(expr);
     auto node_id = nodes_.size();
     nodes_.push_back(node);
     std::vector<JSONGraphNodeEntry> ret;
@@ -195,26 +196,27 @@ class JSONSerializer
     TypeVector dtype;
 
     // Flatten tuple node.
-    if (const auto* tuple_type = checked_type.as<TupleTypeNode>()) {
-      for (size_t i = 0; i < tuple_type->fields.size(); ++i) {
-        const auto* tensor_type = tuple_type->fields[i].as<DynTensorTypeNode>();
-        ICHECK(tensor_type) << "Expect DynTensorType, but received: ."
-                            << tuple_type->fields[i]->GetTypeKey();
-        ICHECK(expr->shape_.defined()) << "Expect shape to be defined. ";
-        ShapeExpr output_shape = Downcast<ShapeExpr>(expr->shape_.value());
+    if (const auto* tuple_sinfo = struct_info.as<TupleStructInfoNode>()) {
+      for (size_t i = 0; i < tuple_sinfo->fields.size(); ++i) {
+        const auto* tensor_sinfo = tuple_sinfo->fields[i].as<TensorStructInfoNode>();
+        ICHECK(tensor_sinfo) << "Expect TensorStructInfo, but received: "
+                             << tuple_sinfo->fields[i]->GetTypeKey();
+        ICHECK(tensor_sinfo->shape.defined()) << "Expect shape to be defined.";
+        ShapeExpr output_shape = Downcast<ShapeExpr>(tensor_sinfo->shape.value());
         ret.push_back(JSONGraphNodeEntry(node_id, i));
         shape.emplace_back(GetIntShape(output_shape->values));
-        dtype.emplace_back(DType2String(tensor_type->dtype));
+        dtype.emplace_back(DType2String(tensor_sinfo->dtype));
       }
-      node->SetNumOutput(tuple_type->fields.size());
+      node->SetNumOutput(tuple_sinfo->fields.size());
     } else {
-      const auto* tensor_type = checked_type.as<DynTensorTypeNode>();
-      ICHECK(tensor_type) << "Expect DynTensorType, but received: " << checked_type->GetTypeKey();
-      ICHECK(expr->shape_.defined()) << "Expect shape to be defined. ";
-      ShapeExpr output_shape = Downcast<ShapeExpr>(expr->shape_.value());
+      const auto* tensor_sinfo = struct_info.as<TensorStructInfoNode>();
+      ICHECK(tensor_sinfo) << "Expect TensorStructInfo, but received: "
+                           << struct_info->GetTypeKey();
+      ICHECK(tensor_sinfo->shape.defined()) << "Expect shape to be defined.";
+      ShapeExpr output_shape = Downcast<ShapeExpr>(tensor_sinfo->shape.value());
 
       shape.emplace_back(GetIntShape(output_shape->values));
-      dtype.emplace_back(DType2String(tensor_type->dtype));
+      dtype.emplace_back(DType2String(tensor_sinfo->dtype));
       ret.push_back(JSONGraphNodeEntry(node_id, 0));
     }
     std::vector<dmlc::any> shape_attrs;

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -105,14 +105,6 @@ class VMShapeLowerMutator : public ExprMutator {
     return builder_->GetContextIRModule();
   }
 
-  void VisitBinding_(const MatchShapeNode* binding) override {
-    Expr value = ExprMutator::VisitExpr(binding->value);
-
-    // TODO(@yuchen): match_shape overloaded semantic: value is ShapeType
-    Var shape = builder_->Emit(Call(ExternFunc("vm.builtin.shape_of"), {value}), "sh");
-    StoreShape(shape, binding->pattern);
-  }
-
   void VisitBinding_(const MatchCastNode* binding) override {
     // TODO(@tqchen): match_cast support for general struct info
     Expr value = ExprMutator::VisitExpr(binding->value);

--- a/src/relax/ir/binding_rewrite.cc
+++ b/src/relax/ir/binding_rewrite.cc
@@ -126,18 +126,8 @@ class UpdateDFB : public ExprMutator {
 };
 
 void DataflowBlockRewriteNode::Add(Binding binding) {
-  auto p = [binding] {
-    if (auto vb = binding.as<VarBindingNode>()) {
-      return std::make_pair(vb->var, vb->value);
-    } else if (auto ms = binding.as<MatchShapeNode>()) {
-      return std::make_pair(ms->var, ms->value);
-    }
-    LOG(FATAL) << "Unsupported binding type";
-    return std::make_pair(Var{}, Expr{});
-  }();
-
-  Var var = p.first;
-  Expr val = p.second;
+  Var var = binding->var;
+  Expr val = binding->value;
 
   ICHECK(0 == to_users_.count(var)) << var << " has been defined so cannot be added.";
 
@@ -156,11 +146,7 @@ void DataflowBlockRewriteNode::Add(Binding binding) {
   size_t line_last_req_def = 0;
   for (size_t i = 0; i < dfb_.value()->bindings.size(); ++i) {
     auto line = dfb_.value()->bindings[i];
-    if (auto varbind = line.as<VarBindingNode>()) {
-      if (used_vars.find(varbind->var.get()) != used_vars.cend()) line_last_req_def = i;
-    } else if (auto mshape = line.as<MatchShapeNode>()) {
-      if (used_vars.find(mshape->var.get()) != used_vars.cend()) line_last_req_def = i;
-    }
+    if (used_vars.find(line->var.get()) != used_vars.cend()) line_last_req_def = i;
   }
 
   auto old_dfb = dfb_.value();
@@ -240,12 +226,8 @@ class RemoveUnusedVars : public ExprMutator {
     auto prev_dfb = GetRef<DataflowBlock>(block);
     builder_->BeginDataflowBlock();
     for (Binding binding : block->bindings) {
-      if (const auto* node = binding.as<VarBindingNode>()) {
-        if (!unused_vars.count(node->var)) VisitBinding_(node);
-      } else if (const auto* node = binding.as<MatchShapeNode>()) {
-        if (!unused_vars.count(node->var)) VisitBinding_(node);
-      } else {
-        LOG(FATAL) << "TypeError: Invalid type: " << binding->GetTypeKey();
+      if (!unused_vars.count(binding->var)) {
+        VisitBinding(binding);
       }
     }
     auto new_dfb = builder_->EndBlock();

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -194,32 +194,13 @@ class BlockBuilderImpl : public BlockBuilderNode {
     return this->Emit(expr, CurrentBlockFrame()->is_dataflow, name_hint);
   }
 
-  Var EmitMatchShape(Expr value, Array<PrimExpr> pattern, String name_hint) final {
-    value = this->Normalize(value);
-
-    BlockFrame* cur_frame = CurrentBlockFrame();
-    Var var = CreateVar(cur_frame->is_dataflow, name_hint);
-
-    if (value->struct_info_.as<ShapeStructInfoNode>()) {
-      UpdateStructInfo(var, ShapeStructInfo(pattern.size()));
-    } else if (const auto* tensor_sinfo = value->struct_info_.as<TensorStructInfoNode>()) {
-      UpdateStructInfo(var, TensorStructInfo(ShapeExpr(pattern), tensor_sinfo->dtype));
-    } else {
-      this->ReportFatal(
-          Diagnostic::Error(value)
-          << "The value passed to EmitMatchShape must be of TensorStructInfo or ShapeStructInfo.");
-    }
-
-    MatchShape match_shape = MatchShape(value, pattern, var);
-    cur_frame->bindings.push_back(match_shape);
-    // NOTE match shape do not follow simple binding rule
-    // as a result should not appear in binding table.
-    return var;
-  }
-
-
   Var EmitMatchCast(Expr value, StructInfo struct_info, String name_hint) final {
     value = this->Normalize(value);
+
+    CHECK(IsBaseOf(GetStructInfo(value), struct_info))
+        << "The struct info of the value expects to be base of the given struct info in MatchCast. "
+           "But got value struct info: "
+        << GetStructInfo(value) << ", given struct info: " << struct_info;
 
     BlockFrame* cur_frame = CurrentBlockFrame();
     Var var = CreateVar(cur_frame->is_dataflow, name_hint);
@@ -253,19 +234,6 @@ class BlockBuilderImpl : public BlockBuilderNode {
       ICHECK(var_binding->value->struct_info_.defined());
       cur_frame->bindings.push_back(binding);
       binding_table_[var_binding->var->vid] = var_binding->value;
-    } else if (const auto* match_shape = binding.as<MatchShapeNode>()) {
-      ICHECK(match_shape);
-      if (match_shape->var.defined()) {
-        if (!cur_frame->is_dataflow) {
-          ICHECK(!match_shape->var.as<DataflowVarNode>())
-              << "Cannot emit dataflowvar in non-dataflow block";
-        }
-        ICHECK(match_shape->var->struct_info_.defined());
-      }
-      ICHECK(match_shape->value->struct_info_.defined());
-      // NOTE match shape do not follow simple binding rule
-      // as a result should not appear in binding table.
-      cur_frame->bindings.push_back(binding);
     } else if (const auto* match_cast = binding.as<MatchCastNode>()) {
       if (!cur_frame->is_dataflow) {
         ICHECK(!match_cast->var.as<DataflowVarNode>())
@@ -710,13 +678,10 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
   Binding VisitBinding(const Binding& binding) {
     if (binding->IsInstance<VarBindingNode>()) {
       return this->VisitVarBinding(Downcast<VarBinding>(binding));
-    } else if (binding->IsInstance<MatchShapeNode>()) {
-      ICHECK(binding.as<MatchShapeNode>()) << "expected VarBinding or MatchShape, got " << binding;
-      return this->VisitMatchShape(Downcast<MatchShape>(binding));
-    } else {
-      ICHECK(binding->IsInstance<MatchCastNode>())
-          << "Unsupported binding type: " << binding->GetTypeKey();
+    } else if (binding->IsInstance<MatchCastNode>()) {
       return this->VisitMatchCast(Downcast<MatchCast>(binding));
+    } else {
+      LOG(FATAL) << "Unsupported binding type: " << binding->GetTypeKey();
     }
   }
 
@@ -731,19 +696,12 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
     return binding;
   }
 
-  MatchShape VisitMatchShape(MatchShape binding) {
-    Expr new_value = this->VisitExpr(binding->value);
-    if (!new_value.same_as(binding->value)) {
-      binding = MatchShape(new_value, binding->pattern, binding->var, binding->span);
-    }
-    if (binding->var.defined() && !binding->var->struct_info_.defined()) {
-      UpdateStructInfo(binding->var, GetStructInfo(new_value));
-    }
-    return binding;
-  }
-
   MatchCast VisitMatchCast(MatchCast binding) {
     Expr new_value = this->VisitExpr(binding->value);
+    CHECK(IsBaseOf(GetStructInfo(new_value), binding->struct_info))
+        << "The struct info of the value expects to be base of the given struct info in MatchCast. "
+           "But got value struct info: "
+        << GetStructInfo(new_value) << ", given struct info: " << binding->struct_info;
     if (!new_value.same_as(binding->value)) {
       binding = MatchCast(binding->var, new_value, binding->struct_info, binding->span);
     }
@@ -852,8 +810,6 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
         Expr value;
         if (const auto* var_binding = binding.as<VarBindingNode>()) {
           value = var_binding->value;
-        } else if (const auto* match_shape = binding.as<MatchShapeNode>()) {
-          value = match_shape->value;
         } else if (const auto* match_cast = binding.as<MatchCastNode>()) {
           value = match_cast->value;
         } else {
@@ -882,8 +838,6 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
 
           if (const auto* var_binding = binding.as<VarBindingNode>()) {
             current.push_back(VarBinding(var_binding->var, seq->body));
-          } else if (const auto* match_shape = binding.as<MatchShapeNode>()) {
-            current.push_back(MatchShape(seq->body, match_shape->pattern, match_shape->var));
           } else if (const auto* match_cast = binding.as<MatchCastNode>()) {
             current.push_back(MatchCast(match_cast->var, seq->body, match_cast->struct_info));
           } else {
@@ -973,11 +927,6 @@ TVM_REGISTER_GLOBAL("relax.BlockBuilderEmit").set_body_typed([](BlockBuilder bui
 TVM_REGISTER_GLOBAL("relax.BlockBuilderEmitMatchCast")
     .set_body_typed([](BlockBuilder builder, Expr value, StructInfo struct_info) {
       return builder->EmitMatchCast(value, struct_info);
-    });
-
-TVM_REGISTER_GLOBAL("relax.BlockBuilderEmitMatchShape")
-    .set_body_typed([](BlockBuilder builder, Expr value, Array<PrimExpr> pattern) {
-      return builder->EmitMatchShape(value, pattern);
     });
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderEmitOutput")

--- a/src/relax/ir/emit_te.cc
+++ b/src/relax/ir/emit_te.cc
@@ -63,7 +63,7 @@ te::Tensor TETensor(Expr value, std::string name) {
   auto* shape_expr = tensor_sinfo->shape.as<ShapeExprNode>();
   CHECK(shape_expr)
       << "ValueError: Expression does not have an known symbolic shape, please consider use "
-         "match_shape "
+         "match_cast "
       << "to constrain the shape before passing into te_tensor";
   n->shape = shape_expr->values;
   n->dtype = tensor_sinfo->dtype;

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -324,22 +324,6 @@ TVM_REGISTER_GLOBAL("relax.Constant").set_body_typed([](runtime::NDArray data, S
 
 TVM_REGISTER_NODE_TYPE(BindingNode);
 
-TVM_REGISTER_NODE_TYPE(MatchShapeNode);
-
-MatchShape::MatchShape(Expr value, Array<PrimExpr> pattern, Var var, Span span) {
-  ObjectPtr<MatchShapeNode> n = make_object<MatchShapeNode>();
-  n->value = std::move(value);
-  n->pattern = std::move(pattern);
-  n->var = std::move(var);
-  n->span = span;
-  data_ = std::move(n);
-}
-
-TVM_REGISTER_GLOBAL("relax.MatchShape")
-    .set_body_typed([](Expr value, Array<PrimExpr> pattern, Var var, Span span) {
-      return MatchShape(value, pattern, var, span);
-    });
-
 TVM_REGISTER_NODE_TYPE(MatchCastNode);
 
 MatchCast::MatchCast(Var var, Expr value, StructInfo struct_info, Span span) {

--- a/src/relax/transform/canonicalize_bindings.cc
+++ b/src/relax/transform/canonicalize_bindings.cc
@@ -68,36 +68,6 @@ class BindingCanonicalizer : public ExprMutator {
     this->builder_->EmitNormalized(VarBinding(new_var, new_value));
   }
 
-  void VisitBinding_(const MatchShapeNode* binding) override {
-    // If we have a trivial shape check (the shape_ of LHS and RHS is the same),
-    // we can canonicalize to a var binding
-    Expr new_value = this->VisitExpr(binding->value);
-
-    Var new_var;
-    // since we do not permit the checked_type to change and don't make any changes
-    // to the shape pattern, there is no reason to do any more checking like in the
-    // original mutator
-    if (binding->var.defined()) {
-      new_var = this->VisitVarDef(binding->var);
-    }
-
-    // if the LHS and RHS have the same shape_, we canonicalize to a var binding instead
-    if (new_var.defined() && StructuralEqual()(GetStructInfo(new_var), GetStructInfo(new_value))) {
-      builder_->EmitNormalized(VarBinding(new_var, new_value));
-      return;
-    }
-
-    // reemit old binding if nothing changes
-    if (new_value.same_as(binding->value)) {
-      if (!binding->var.defined() || (binding->var.defined() && new_var.same_as(binding->var))) {
-        builder_->EmitNormalized(GetRef<MatchShape>(binding));
-        return;
-      }
-    }
-
-    builder_->EmitNormalized(MatchShape(new_value, binding->pattern, new_var));
-  }
-
   void VisitBinding_(const MatchCastNode* binding) override {
     // If we have a trivial shape check (the shape_ of LHS and RHS is the same),
     // we can canonicalize to a var binding

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -136,7 +136,7 @@ class GraphCreator : public ExprVisitor {
     // We skip ordinary binding blocks since they might be impure (with side effect or control flow)
   }
 
-  // TODO(tvm-team): how to deal with MatchShape binding here
+  // TODO(tvm-team): how to deal with MatchCast binding here
 
   void VisitBinding_(const VarBindingNode* binding) final {
     IndexedForwardGraph::Node* node = CreateNode(binding->var.get());
@@ -394,7 +394,7 @@ class FunctionCreator : public ExprMutator {
         AppendOutput(var_binding->var);
       }
     } else {
-      // TODO(tvm-team): handle match_shape
+      // TODO(tvm-team): handle match_cast
     }
     bindings_.push_back(binding);
   }
@@ -416,14 +416,7 @@ class FunctionCreator : public ExprMutator {
     // Step 2. Visit each binding and collect outputs one by one.
     Array<Expr> outputs;
     for (const Binding& binding : bindings_) {
-      const VarNode* var = nullptr;
-      if (const auto* var_binding = binding.as<VarBindingNode>()) {
-        var = var_binding->var.get();
-      } else if (const auto* match_shape = binding.as<MatchShapeNode>()) {
-        var = match_shape->var.get();
-      } else {
-        ICHECK(false);
-      }
+      const VarNode* var = binding->var.get();
       if (output_vars_.count(var)) {
         // Case 1. It is an output binding
         // We only allow VarBinding as output.
@@ -687,13 +680,7 @@ class OperatorFusor : public ExprMutator {
           }
         }
       };
-      if (const auto* var_binding = binding.as<VarBindingNode>()) {
-        PostOrderVisit(var_binding->value, update_boundary);
-      } else {
-        const auto* match_shape = binding.as<MatchShapeNode>();
-        ICHECK_NOTNULL(match_shape);
-        PostOrderVisit(match_shape->value, update_boundary);
-      }
+      PostOrderVisit(binding->value, update_boundary);
     }
   }
 
@@ -703,14 +690,7 @@ class OperatorFusor : public ExprMutator {
    * \return The pointer to the group which the input binding is in
    */
   GraphPartitioner::Group* GetGroupFromBinding(const Binding& binding) {
-    Var var{nullptr};
-    if (const auto* var_binding = binding.as<VarBindingNode>()) {
-      var = var_binding->var;
-    } else {
-      const auto* match_shape = binding.as<MatchShapeNode>();
-      ICHECK(match_shape != nullptr);
-      var = match_shape->var;
-    }
+    Var var = binding->var;
     return GetGroupFromVar(var);
   }
 

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -289,11 +289,7 @@ class FusedTIRConstructor : public ExprVisitor {
     }
   }
 
-  void VisitBinding_(const MatchShapeNode* match_shape) final {
-    LOG(FATAL) << "MatchShape is unsupported in primitive functions";
-  }
-
-  void VisitBinding_(const MatchCastNode* match_shape) final {
+  void VisitBinding_(const MatchCastNode* match_cast) final {
     LOG(FATAL) << "MatchCast is unsupported in primitive functions";
   }
 

--- a/src/relax/transform/normalize.cc
+++ b/src/relax/transform/normalize.cc
@@ -132,8 +132,6 @@ class NormalizeMutator : public ExprMutatorBase {
   void VisitBinding(const Binding& binding) {
     if (const auto* node = binding.as<VarBindingNode>()) {
       VisitBinding_(node);
-    } else if (const auto* node = binding.as<MatchShapeNode>()) {
-      VisitBinding_(node);
     } else if (const auto* node = binding.as<MatchCastNode>()) {
       VisitBinding_(node);
     } else {
@@ -151,21 +149,6 @@ class NormalizeMutator : public ExprMutatorBase {
       builder_->EmitNormalized(GetRef<VarBinding>(binding));
     } else {
       builder_->EmitNormalized(VarBinding(binding->var, new_value));
-    }
-  }
-
-  void VisitBinding_(const MatchShapeNode* binding) {
-    Expr new_value = this->VisitExpr(binding->value);
-
-    if (binding->var.defined()) {
-      if (!binding->var->struct_info_.defined()) {
-        UpdateStructInfo(binding->var, GetStructInfo(new_value));
-      }
-    }
-    if (new_value.same_as(binding->value)) {
-      builder_->EmitNormalized(GetRef<MatchShape>(binding));
-    } else {
-      builder_->EmitNormalized(MatchShape(new_value, binding->pattern, binding->var));
     }
   }
 

--- a/src/script/ir_builder/relax/frame.cc
+++ b/src/script/ir_builder/relax/frame.cc
@@ -160,21 +160,8 @@ void BlockFrameNode::ExitWithScope() {
     // Step 3.2. Collect global vars' reference in bindings
     Map<tvm::relax::Id, tvm::relax::Var> new_global_vars;
     for (const tvm::relax::Binding& binding : block->bindings) {
-      if (const auto* var_binding = binding.as<tvm::relax::VarBindingNode>()) {
-        if (!var_binding->var->IsInstance<tvm::relax::DataflowVarNode>()) {
-          new_global_vars.Set(var_binding->var->vid, var_binding->var);
-        }
-      } else if (const auto* match_shape = binding.as<tvm::relax::MatchShapeNode>()) {
-        if (match_shape->var.defined() &&
-            !match_shape->var->IsInstance<tvm::relax::DataflowVarNode>()) {
-          new_global_vars.Set(match_shape->var->vid, match_shape->var);
-        }
-      } else if (const auto* match_cast = binding.as<tvm::relax::MatchCastNode>()) {
-        if (!match_cast->var->IsInstance<tvm::relax::DataflowVarNode>()) {
-          new_global_vars.Set(match_cast->var->vid, match_cast->var);
-        }
-      } else {
-        LOG(FATAL) << "ValueError: Unsupported binding type: " << binding;
+      if (!binding->var->IsInstance<tvm::relax::DataflowVarNode>()) {
+        new_global_vars.Set(binding->var->vid, binding->var);
       }
     }
 

--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -204,26 +204,6 @@ tvm::relax::Var Emit(const tvm::relax::Expr& expr) {
   return var;
 }
 
-Optional<tvm::relax::Var> EmitMatchShape(const tvm::relax::Expr& value,   //
-                                         const Array<PrimExpr>& pattern,  //
-                                         bool emit_var) {
-  BlockFrame block_frame = CheckBlockFrameExistAndUnended();
-  tvm::relax::BlockBuilder block_builder = GetBlockBuilder();
-
-  if (!emit_var) {
-    // If we don't intend to emit a variable, just emit the binding and return.
-    tvm::relax::MatchShape match_shape(block_builder->Normalize(value), pattern,
-                                       tvm::relax::Var{nullptr});
-    block_builder->EmitNormalized(match_shape);
-    return NullOpt;
-  } else {
-    // Otherwise, we need to emit a variable and bind it to the match shape.
-    tvm::relax::Var var = block_builder->EmitMatchShape(value, pattern);
-    block_frame->emitted_vars.push_back(var);
-    return var;
-  }
-}
-
 tvm::relax::Var EmitMatchCast(const tvm::relax::Expr& value,
                               const tvm::relax::StructInfo& struct_info) {
   BlockFrame block_frame = CheckBlockFrameExistAndUnended();
@@ -235,7 +215,6 @@ tvm::relax::Var EmitMatchCast(const tvm::relax::Expr& value,
 }
 
 TVM_REGISTER_GLOBAL("script.ir_builder.relax.Emit").set_body_typed(Emit);
-TVM_REGISTER_GLOBAL("script.ir_builder.relax.EmitMatchShape").set_body_typed(EmitMatchShape);
 TVM_REGISTER_GLOBAL("script.ir_builder.relax.EmitMatchCast").set_body_typed(EmitMatchCast);
 
 ///////////////////////////// Type Deduce //////////////////////////////

--- a/src/script/ir_builder/relax/utils.h
+++ b/src/script/ir_builder/relax/utils.h
@@ -85,20 +85,10 @@ inline tvm::relax::SeqExpr GetSeqExprForBranch(const SeqExprFrame& frame, String
   // Step 2. Collect body from the last binding.
   tvm::relax::Expr body;
   const tvm::relax::Binding& last_binding = last_block->bindings.back();
-  if (const auto* var_binding = last_binding.as<tvm::relax::VarBindingNode>()) {
-    CHECK(!var_binding->var->IsInstance<tvm::relax::DataflowVarNode>())
-        << "A non-dataflow var is expected in the last binding of '" << method << "'.";
-    body = var_binding->value;
-    *var_name = var_binding->var->name_hint();
-  } else if (const auto* match_shape = last_binding.as<tvm::relax::MatchShapeNode>()) {
-    CHECK(match_shape->var.defined() &&
-          !match_shape->var->IsInstance<tvm::relax::DataflowVarNode>())
-        << "A non-dataflow var is expected in the last binding of '" << method << "'.";
-    body = var_binding->value;
-    *var_name = match_shape->var->name_hint();
-  } else {
-    ICHECK(false) << "TypeError: Unsupported binding type: " << last_binding->GetTypeKey();
-  }
+  CHECK(!last_binding->var->IsInstance<tvm::relax::DataflowVarNode>())
+      << "A non-dataflow var is expected in the last binding of '" << method << "'.";
+  body = last_binding->value;
+  *var_name = last_binding->var->name_hint();
 
   // Step 3. Re-collect binding blocks to remove the last binding.
   Array<tvm::relax::BindingBlock> new_blocks(frame->binding_blocks.begin(),

--- a/tests/python/relax/test_analysis.py
+++ b/tests/python/relax/test_analysis.py
@@ -267,11 +267,11 @@ class VarExample:
     def main(x: R.Tensor, y: R.Tensor) -> R.Tensor:
         z = R.add(x, y)
         # no binding here
-        R.match_shape(x, (5, 5))
+        _ = R.match_cast(x, R.Tensor((5, 5)))
         with R.dataflow():
             q = R.add(z, z)
             p = func(q)
-            r = R.match_shape(p, (5, 5))
+            r = R.match_cast(p, R.Tensor((5, 5)))
             s = r
             R.output(s)
         return s
@@ -285,7 +285,7 @@ def test_all_vars():
     assert vars[1] == VarExample["func"].body.body
 
     var_names = var_name_set(all_vars(VarExample["main"]))
-    assert var_names == {"x", "y", "z", "p", "q", "r", "s"}
+    assert var_names == {"_", "x", "y", "z", "p", "q", "r", "s"}
 
 
 def test_bound_vars():
@@ -297,11 +297,11 @@ def test_bound_vars():
 
     # all the vars are bound
     var_names = var_name_set(bound_vars(VarExample["main"]))
-    assert var_names == {"x", "y", "z", "p", "q", "r", "s"}
+    assert var_names == {"_", "x", "y", "z", "p", "q", "r", "s"}
 
     # if we consider only the body, then the function arguments are not bound
     body_names = var_name_set(bound_vars(VarExample["main"].body))
-    assert body_names == {"z", "p", "q", "r", "s"}
+    assert body_names == {"_", "z", "p", "q", "r", "s"}
 
     # only binding is in the (normalized) body
     simple_body_vars = bound_vars(VarExample["func"].body)

--- a/tests/python/relax/test_autotir_integration.py
+++ b/tests/python/relax/test_autotir_integration.py
@@ -66,9 +66,9 @@ class InputModule:
     def main(x:R.Tensor((m,n), "float32"), w:R.Tensor((n,k), "float32")) -> R.Tensor:
         with R.dataflow():
             sh = R.call_packed("vm.builtin.shape_of", x)
-            x0 = R.match_shape(sh, (m, n))
+            x0 = R.match_cast(sh, R.Tensor((m, n), "float32"))
             sh1 = R.call_packed("vm.builtin.shape_of", w)
-            x1 = R.match_shape(sh1, (n, k))
+            x1 = R.match_cast(sh1, R.Tensor((n, k), "float32"))
             lv0 = R.call_tir(tir_matmul, (x, w), (m, k), dtype="float32")
             lv1 = R.call_tir(tir_relu, (lv0), (m, k), dtype="float32)
             R.output(lv1)

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -67,13 +67,13 @@ def test_dataflow_var() -> None:
     tvm.ir.assert_structural_equal(v1.struct_info, rx.TensorStructInfo(shape, "float16"))
 
 
-def test_match_shape() -> None:
-    # match_shape([16, 8], [m, n])
+def test_match_cast() -> None:
+    # match_cast([16, 8], [m, n])
     m = tir.Var("m", dtype="int64")
     n = tir.Var("n", dtype="int64")
     shape = rx.const([16, 8], "int32")
     var = rx.Var("v0", R.Shape())
-    b0 = rx.MatchShape(shape, [m, n], var)
+    b0 = rx.MatchCast(var, shape, R.Tensor([m, n], "int32"))
     assert b0.value == shape
     assert b0.pattern[0] == m
     assert b0.pattern[1] == n
@@ -81,11 +81,11 @@ def test_match_shape() -> None:
     assert b0.var.checked_type == rx.ShapeType()
 
     # var1: R.Tensor((m, n), "float32") =
-    #   match_shape(var0: R.Tensor("float32", ndim=-1), [m, n])
+    #   match_cast(var0: R.Tensor("float32", ndim=-1), R.Tensor((m, n), "float32"))
     value = rx.Var("value", R.Tensor("float32", ndim=-1))
 
     var = rx.Var("v1", R.Tensor([m, n], "float32"))
-    b1 = rx.MatchShape(value, [m, n], var)
+    b1 = rx.MatchCast(var, value, R.Tensor([m, n], "float32"))
     assert b1.value == value
     assert b1.pattern[0] == m
     assert b1.pattern[1] == n
@@ -113,10 +113,10 @@ def test_var_binding() -> None:
 
 
 def test_binding_block() -> None:
-    m = tir.Var("m", dtype="int32")
-    n = tir.Var("n", dtype="int32")
+    m = tir.Var("m", dtype="int64")
+    n = tir.Var("n", dtype="int64")
     shape = rx.const([16, 8], "int32")
-    b0 = rx.MatchShape(shape, [m, n], rx.Var("v0"))
+    b0 = rx.MatchCast(rx.Var("v0"), shape, R.Tensor([m, n], "int32"))
 
     v0 = rx.Var("v0")
     val = rx.const(np.random.rand(24, 56))
@@ -128,10 +128,10 @@ def test_binding_block() -> None:
 
 
 def test_dataflow_block() -> None:
-    m = tir.Var("m", dtype="int32")
-    n = tir.Var("n", dtype="int32")
+    m = tir.Var("m", dtype="int64")
+    n = tir.Var("n", dtype="int64")
     shape = rx.const([16, 8], "int32")
-    b0 = rx.MatchShape(shape, [m, n], rx.Var("v0"))
+    b0 = rx.MatchCast(rx.Var("v0"), shape, R.Tensor([m, n], "int32"))
 
     v0 = rx.Var("v0")
     val = rx.const(np.random.rand(24, 56))

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -64,11 +64,11 @@ def test_ndim_annotations():
     check_roundtrip(foo)
 
 
-def test_match_shape():
+def test_match_cast():
     @R.function
     def foo(x: R.Tensor(dtype="float32")):
         n, m = T.var("int64"), T.var("int64")
-        R.match_shape(R.shape_of(x), (n, m))
+        _ = R.match_cast(R.shape_of(x), R.Shape((n, m)))
         y: R.Tensor((n, m), "float32") = R.add(x, x)
         return x
 
@@ -141,15 +141,15 @@ def test_dataflow():
     check_roundtrip(foo)
 
 
-def test_dataflow_match_shape():
+def test_dataflow_match_cast():
     @R.function
     def foo(x: R.Tensor(ndim=2)):
         n, m = T.var("int64"), T.var("int64")
         with R.dataflow():
-            x2: R.Tensor((n, m)) = R.match_shape(x, (n, m))
+            x2: R.Tensor((n, m)) = R.match_cast(x, R.Tensor((n, m)))
             y = R.add(x2, x2)
             z = R.multiply(y, x)
-            R.match_shape(R.shape_of(z), (n, m))
+            _ = R.match_cast(R.shape_of(z), R.Shape((n, m)))
             w: R.Tensor((n, m)) = R.add(z, x)
             R.output(y, w, x2)
         t: R.Tensor((n, m)) = R.multiply(y, w)

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -327,7 +327,7 @@ def test_class_irmodule():
             return r
 
         @R.function
-        def g(y: R.Tensor(("n", "n"))) -> R.Tensor:
+        def g(y: R.Tensor(("n", "n"))) -> R.Tensor(("n", "n"), "float32"):
             n = T.var("int64")
             r = relax.call_tir(my_matmul, (y, y), (n, n), dtype="float32")
             return r

--- a/tests/python/relax/test_structual_equal_hash.py
+++ b/tests/python/relax/test_structual_equal_hash.py
@@ -53,14 +53,14 @@ def test_var_binding():
     _check_equal(block0, block1)
 
 
-def test_match_shape():
+def test_match_cast():
     x = rx.Var("x", R.Tensor([10]))
     m = tir.Var("m", dtype="int64")
 
     def generator(x):
         bb = rx.BlockBuilder()
         bb._begin_binding_block()
-        bb.match_shape(x, [m * 2])
+        bb.match_cast(x, R.Tensor([m * 2]))
         return bb._end_block()
 
     block0 = generator(x)
@@ -108,13 +108,13 @@ def test_ir_module():
     _check_equal(mod0, mod1)
 
 
-def test_match_shape_symbolic():
+def test_match_cast_symbolic():
     @tvm.script.ir_module
     class InputModule:
         @R.function
         def f(x: R.Tensor("float32", ndim=2)):
             n, m = T.var("int64"), T.var("int64")
-            x0 = R.match_shape(x, (n, m))
+            x0 = R.match_cast(x, R.Tensor((n, m), "float32"))
             return (x0, (n + 1, m))
 
     _check_save_roundtrip(InputModule)

--- a/tests/python/relax/test_transform_canonicalize_bindings.py
+++ b/tests/python/relax/test_transform_canonicalize_bindings.py
@@ -135,14 +135,14 @@ def test_casting():
     assert_structural_equal(new_mod, Expected)
 
 
-def test_match_shape():
+def test_match_cast():
     @tvm.script.ir_module
-    class TestMatchShape:
+    class TestMatchCast:
         @R.function
         def main(x: R.Tensor):
             q = x
             m, n = T.var("int64"), T.var("int64")
-            z = R.match_shape(q, (m, n))
+            z = R.match_cast(q, R.Tensor((m, n)))
             w = z
             return w
 
@@ -153,11 +153,11 @@ def test_match_shape():
             q = x
             # can't get rid of z because its shape_ is different from x's
             m, n = T.var("int64"), T.var("int64")
-            z = R.match_shape(x, (m, n))
+            z = R.match_cast(x, R.Tensor((m, n)))
             w = z
             return z
 
-    new_mod = relax.transform.CanonicalizeBindings()(TestMatchShape)
+    new_mod = relax.transform.CanonicalizeBindings()(TestMatchCast)
     assert_structural_equal(new_mod, Expected)
 
 

--- a/tests/python/relax/test_transform_fold_constant.py
+++ b/tests/python/relax/test_transform_fold_constant.py
@@ -207,7 +207,7 @@ def test_fold_mixed_case():
         @R.function
         def before(c0: R.Tensor((16, 16), "float32"), x: R.Tensor("float32", ndim=2)):
             n, m = T.var("int64"), T.var("int64")
-            x0 = R.match_shape(x, (n, m))
+            x0 = R.match_cast(x, R.Tensor((n, m), "float32"))
             # this line cannot be folded because n is unknown
             lv0 = relax.call_tir(addone, (c0,), (n, 16), dtype="float32")
             # this line can be folded
@@ -226,7 +226,7 @@ def test_fold_mixed_case():
             x: R.Tensor("float32", ndim=2),
         ) -> R.Tensor:
             n, m = T.var("int64"), T.var("int64")
-            x0 = R.match_shape(x, (n, m))
+            x0 = R.match_cast(x, R.Tensor((n, m), "float32"))
             # this line cannot be folded because n is unknown
             lv0 = relax.call_tir(addone, (c0,), (n, 16), dtype="float32")
             # this line can be folded

--- a/tests/python/relax/test_transform_normalize.py
+++ b/tests/python/relax/test_transform_normalize.py
@@ -454,6 +454,7 @@ def test_normalize_deeply_nested_seq():
     u = relax.Var("u", R.Tensor([], "int32"))
     v = relax.Var("v", R.Tensor([], "int32"))
     w = relax.Var("w", R.Tensor([], "int32"))
+    _ = relax.Var("w", R.Tensor([], "int32"))
     seq = relax.SeqExpr(
         [
             relax.BindingBlock(
@@ -472,9 +473,13 @@ def test_normalize_deeply_nested_seq():
                                                     relax.BindingBlock(
                                                         [
                                                             relax.VarBinding(u, relax.const(2)),
-                                                            relax.MatchShape(u, [], None),
+                                                            relax.MatchCast(
+                                                                _, u, R.Tensor([], "int32")
+                                                            ),
                                                             relax.VarBinding(v, u),
-                                                            relax.MatchShape(v, [], w),
+                                                            relax.MatchCast(
+                                                                w, v, R.Tensor([], "int32")
+                                                            ),
                                                         ]
                                                     )
                                                 ],
@@ -504,9 +509,9 @@ def test_normalize_deeply_nested_seq():
     def expected():
         x = relax.const(1)
         u = relax.const(2)
-        R.match_shape(u, ())
+        _ = R.match_cast(u, R.Tensor((), "int32"))
         v = u
-        w = R.match_shape(v, ())
+        w = R.match_cast(v, R.Tensor((), "int32"))
         z = w
         y = z
         return y

--- a/tests/python/relax/test_tvmscript_ir_builder.py
+++ b/tests/python/relax/test_tvmscript_ir_builder.py
@@ -53,14 +53,14 @@ def test_function_simple():
     assert func.body.body.name_hint == "out"
 
 
-def test_match_shape():
+def test_match_cast():
     """
     @R.function
     def foo(x: R.Tensor(None, "float32"), y: R.Tensor(None, "float32")):
         m = T.var("int64")
         n = T.var("int64")
-        R.match_shape(x, (m,))
-        y1 = R.match_shape(x, (n,))
+        _ = R.match_cast(x, R.Tensor((m,), "float32"))
+        y1 = R.match_cast(x, R.Tensor((n,), "float32"))
         return (m, n * 2)
     """
     # create with Script IRBuilder
@@ -71,8 +71,8 @@ def test_match_shape():
             y = R.arg("y", R.tensor(ndim=-1, dtype="float32"))
             m = tir.Var("m", dtype="int64")
             n = tir.Var("n", dtype="int64")
-            R.emit_match_shape(x, (m,), emit_var=False)
-            y1 = R.emit_match_shape(y, (n,), emit_var=True)
+            _ = R.emit_match_cast(x, R.tensor((m,), "float32"))
+            y1 = R.emit_match_cast(y, R.tensor((n,), "float32"))
             IRBuilder.name("y1", y1)
             R.func_ret_value(relax.ShapeExpr([m, n * 2]))
     func = ir_builder.get()
@@ -84,8 +84,8 @@ def test_match_shape():
     n = tir.Var("n", dtype="int64")
     bb = relax.BlockBuilder()
     with bb.function("foo", (x, y)):
-        bb.emit_normalized(relax.MatchShape(x, (m,), var=None))
-        y1 = bb.match_shape(y, (n,))
+        _ = bb.match_cast(x, R.tensor((m,), "float32"))
+        y1 = bb.match_cast(y, R.tensor((n,), "float32"))
         bb.emit_func_output(relax.ShapeExpr([m, n * 2]))
     mod = bb.get()
 

--- a/tests/python/relay/test_dataflow_pattern.py
+++ b/tests/python/relay/test_dataflow_pattern.py
@@ -422,13 +422,13 @@ def test_no_match_dtype():
     assert not ty_pat.match(x)
 
 
-def test_match_shape():
+def test_match_cast():
     x = relay.var("x", shape=(10, 10), dtype="float32")
     ty_pat = has_shape((10, 10))
     assert ty_pat.match(x)
 
 
-def test_no_match_shape():
+def test_no_match_cast():
     x = relay.var("x", shape=(10, 10), dtype="int32")
     ty_pat = has_shape((10, 5))
     assert not ty_pat.match(x)


### PR DESCRIPTION
This PR removes the match_shape and passes most of the test cases.

There is one thing left:
I add a validation check at emit_match_shape and normalizer in the block builder to check if the given struct_info is compatible with the input var. However, the `BaseOf` seems too strict in this case, since:

`R.Tensor(128, 128)` is not base_of `R.Tensor([m, n])`, but it's legal to match `[m, n]` to `[128, 128]`